### PR TITLE
function signature in paragraph header didn't match the actual code. als...

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ once a valid `Request Token` is generated.
 
 ### Authorization
 
-The next step is to redirect the user to the dropbox endpoint to recieve
+The next step is to redirect the user to the dropbox endpoint to receive
 authorization from the user. Dbox makes no attempt to do this for you. Simply
 pass in the `oauth_token` into the querystring.
 
     https://www.dropbox.com/1/oauth/authorize?oauth_token=h89r0sdfdsfwiko
 
-### access_token(callback)
+### access_token(options, callback)
 
 Once the user has granted authorization we can now generate the access token
 using the request token to sign the request.


### PR DESCRIPTION
...o, 'receive' was misspelled
