### PR TITLE
Use `querystring.parse` on token responses

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -18,12 +18,7 @@ exports.createClient = function(config){
         "body": qs.stringify(signature)
       }
       request(args, function(e, r, b){
-        var obj = {}
-        b.split("&").forEach(function(kv){
-          var kv = kv.split("=")
-          obj[kv[0]] = kv[1] 
-        })
-        cb(r.statusCode, obj)
+        cb(r.statusCode, qs.parse(b))
       })
     },
     build_authorize_url: function(oauth_token, oauth_callback){
@@ -42,12 +37,7 @@ exports.createClient = function(config){
         "body": qs.stringify(params)
       }
       request(args, function(e, r, b){
-        var obj = {}
-        b.split("&").forEach(function(kv){
-          var kv = kv.split("=")
-          obj[kv[0]] = kv[1] 
-        })
-        cb(r.statusCode, obj)
+        cb(r.statusCode, qs.parse(b))
       })
     },
 


### PR DESCRIPTION
Replace code to parse response bodies with calls to `querystring.parse`.
