### PR TITLE
Return `null` instead of `r.statusCode` if an error occurred

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -18,7 +18,7 @@ exports.createClient = function(config){
         "body": qs.stringify(signature)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, qs.parse(b))
+        cb(e ? null : r.statusCode, qs.parse(b))
       })
     },
     build_authorize_url: function(oauth_token, oauth_callback){
@@ -37,7 +37,7 @@ exports.createClient = function(config){
         "body": qs.stringify(params)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, qs.parse(b))
+        cb(e ? null : r.statusCode, qs.parse(b))
       })
     },
 
@@ -50,7 +50,7 @@ exports.createClient = function(config){
         "body": qs.stringify(params)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, JSON.parse(b))
+        cb(e ? null : r.statusCode, JSON.parse(b))
       })
     },
 
@@ -63,7 +63,7 @@ exports.createClient = function(config){
         "encoding": null
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, b)
+        cb(e ? null : r.statusCode, b)
       })
     },
 
@@ -76,7 +76,7 @@ exports.createClient = function(config){
         "body": body 
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, JSON.parse(b))
+        cb(e ? null : r.statusCode, JSON.parse(b))
       })
     },
 
@@ -87,7 +87,7 @@ exports.createClient = function(config){
         "url": "https://api.dropbox.com/1/metadata/" + (params.root || root) + "/" + qs.escape(path) + "?" + qs.stringify(params)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, b)
+        cb(e ? null : r.statusCode, b)
       })
     },
 
@@ -98,7 +98,7 @@ exports.createClient = function(config){
         "url": "https://api.dropbox.com/1/revisions/" + (params.root || root) + "/" + qs.escape(path) + "?" + qs.stringify(params)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, JSON.parse(b))
+        cb(e ? null : r.statusCode, JSON.parse(b))
       })
     },
 
@@ -117,7 +117,7 @@ exports.createClient = function(config){
         "body": qs.stringify(params)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, b)
+        cb(e ? null : r.statusCode, b)
       })
     },
 
@@ -136,7 +136,7 @@ exports.createClient = function(config){
         "body": body
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, JSON.parse(b))
+        cb(e ? null : r.statusCode, JSON.parse(b))
       })
     },
 
@@ -153,7 +153,7 @@ exports.createClient = function(config){
         "body": body
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, b)
+        cb(e ? null : r.statusCode, b)
       })
     },
 
@@ -170,7 +170,7 @@ exports.createClient = function(config){
         "body": body
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, b)
+        cb(e ? null : r.statusCode, b)
       })
     },
 
@@ -182,7 +182,7 @@ exports.createClient = function(config){
         "encoding": null
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, b)
+        cb(e ? null : r.statusCode, b)
       })
     },
 
@@ -198,7 +198,7 @@ exports.createClient = function(config){
         "body": qs.stringify(params)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, JSON.parse(b))
+        cb(e ? null : r.statusCode, JSON.parse(b))
       })
     },
 
@@ -216,7 +216,7 @@ exports.createClient = function(config){
       }
 
       request(args, function(e, r, b){
-        cb(r.statusCode, JSON.parse(b))
+        cb(e ? null : r.statusCode, JSON.parse(b))
       })
     },
 
@@ -231,7 +231,7 @@ exports.createClient = function(config){
         "body": qs.stringify(params)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, JSON.parse(b))
+        cb(e ? null : r.statusCode, JSON.parse(b))
       })
     },
 
@@ -246,7 +246,7 @@ exports.createClient = function(config){
         "body": qs.stringify(params)
       }
       request(args, function(e, r, b){
-        cb(r.statusCode, JSON.parse(b))
+        cb(e ? null : r.statusCode, JSON.parse(b))
       })
     }
 


### PR DESCRIPTION
If an error occurs connecting to Dropbox the request library will return an error and no response, causing a fatal error when attempting to access the `statusCode` property.  This change will return a `null` value instead of `r.statusCode` from dropbox client methods if an error occurs, allowing the calling application to handle the error more gracefully.

A better solution might be to follow the node callback convention by passing the request error object as the first parameter to callbacks, but as that will break every function signature I've left it alone for now.
