### PR TITLE
Dropbox metadata method can return 304 when hash is provided

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -127,7 +127,11 @@ exports.app = function(config){
             "url": "https://api.dropbox.com/1/metadata/" + (params.root || root) + "/" + qs.escape(path) + "?" + qs.stringify(params)
           }
           request(args, function(e, r, b){
-            cb(e ? null : r.statusCode, JSON.parse(b))
+            // this is a special case, since the dropbox api returns a
+            // 304 response with an empty body when the 'hash' option
+            // is provided and there have been no changes since the
+            // hash was computed
+            cb(e ? null : r.statusCode, r.statusCode == 304 ? {} : JSON.parse(b))
           })
         },
 


### PR DESCRIPTION
The dropbox metadata method returns 304 when the hash option is provided
and the server hash is the same.  This pull req is the simplest solution I could come up with.  Not sure if it is the expected response for everyone, but it is the expected response in my app.
