### PR TITLE
Callback should return metadata in /get and /thumbnail methods.

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -89,7 +89,7 @@ exports.app = function(config){
             "encoding": null
           }
           request(args, function(e, r, b){
-            cb(r.statusCode, b)
+            cb(r.statusCode, b, r.headers['x-dropbox-metadata'])
           })
         },
 
@@ -286,7 +286,7 @@ exports.app = function(config){
             "encoding": null
           }
           request(args, function(e, r, b){
-            cb(e ? null : r.statusCode, b)
+            cb(e ? null : r.statusCode, b, r.headers['x-dropbox-metadata'])
           })
         },
 


### PR DESCRIPTION
Dropbox sends a custom HTTP header (x-dropbox-metadata) which is easily accessible using Request's http.ClientResponse instance. Only /get and /thumbnail API resources come with that header.

This is important as we can get a file and handle its metadata in a single HTTP request
