### PR TITLE
Dropbox GET (file) metadata

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -89,7 +89,7 @@ exports.app = function(config){
             "encoding": null
           }
           request(args, function(e, r, b){
-            cb(r.statusCode, b)
+            cb(r.statusCode, b, r.headers["x-dropbox-metadata"])
           })
         },
 


### PR DESCRIPTION
https://www.dropbox.com/developers/reference/api#files-GET

specifies that "The HTTP response contains the content metadata in JSON format within an x-dropbox-metadata header."

When downloading a file, it would be nice to also get the metadata that is sent from dropbox. Added one liner addition to parse and send metadata to client.
