### PR TITLE
Corrected error #35, changed line so it refers to metadata correctly

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -98,7 +98,7 @@ exports.app = function(config){
             "encoding": null
           }
           return request(args, function(e, r, b){
-            cb(r.statusCode, b, r.headers['x-dropbox-metadata'])
+            cb(r.statusCode, b, JSON.parse( r.headers['x-dropbox-metadata'] ) )
           })
         },
 


### PR DESCRIPTION
Updated dbox.js line 180 so it now correctly refers to metadata
