### PR TITLE
Add readdir options: recursive, details

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -201,7 +201,6 @@ exports.app = function(config){
                 //
                 if (reply.contents) {
                   reply.contents.forEach(function (item) {
-                    console.log("item:", item);
                     //
                     // Add the item into our results array (details or path)
                     //


### PR DESCRIPTION
This adds an `options` parameter to `client.readdir`, with 2 options: 
- `recursive`: Added because a recursive traversal of a user's entire Dropbox can be terrible for performance. In our case we want the user to traverse manually only as deeply as needed.
- `details`: if true, returns the whole `item` object for each item, not just the path.

All of this is added in a completely backwards-compatible way, maintaining the original behavior for users who don't explicitly specify these parameters.
