### PR TITLE
modified the stream function to use set_args

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -110,9 +110,7 @@ exports.app = function(config){
         stream: function(path, args) {
           var params = sign(options);
           
-          for(var attr in args)(function(attr){
-            options[attr] = args[attr]
-          })(attr)
+          set_args(params, args);
 
           var args = {
             "method": "GET",
@@ -122,7 +120,7 @@ exports.app = function(config){
 
           return request(args);
 
-        },
+        },        
 
         put: function(path, body, args, cb){
           var params = sign(options)


### PR DESCRIPTION
I was using the stream function, but getting an error from dropbox because my app is set to use "dropbox" instead of sandbox, and the argument I tried passing into stream wasn't getting set correctly.

I changed the stream function to use the set_args function, which is more consistent with the rest of the library.

Thanks for making dbox!
