### PR TITLE
Don't try reading length of undefined

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -142,7 +142,7 @@ exports.app = function(config){
 
           var args = {
             "method": "PUT",
-            "headers": { "content-length": body.length },
+            "headers": { "content-length": body ? body.length : 0 },
             "url": "https://api-content.dropbox.com/1/files_put/" + (params.root || root) + "/" + qs.escape(path) + "?" + qs.stringify(params),
             "body": body 
           }


### PR DESCRIPTION
When trying to put "nothing", really just `null`, dbox tries to read `null.length`, which blows things up. Using an empty Buffer fails too, because request expects everything that is "something" to have a length greater than zero. But, request supports both an empty string and null, so should dbox.
