### PR TITLE
Fix bug: Empty Content-Type in put method

### DIFF
--- a/dbox.js
+++ b/dbox.js
@@ -142,7 +142,10 @@ exports.app = function(config){
 
           var args = {
             "method": "PUT",
-            "headers": { "content-length": body.length },
+            "headers": { 
+              "content-length": body.length, 
+              "content-type": params["Content-Type"] || "binary" 
+            },
             "url": "https://api-content.dropbox.com/1/files_put/" + (params.root || root) + "/" + qs.escape(path) + "?" + qs.stringify(params),
             "body": body 
           }


### PR DESCRIPTION
Today i catch this bad response from DropBox:
"Upload failed. Content-Type must not be empty and not one of (\'application/x-www-form-urlencoded\', \'multipart/form-data\'"

It is my quick fix.
