### PR TITLE
fix issue #64

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -111,13 +111,13 @@ module.exports = function(config){
       var fileop   = obj.action.split("/")[0] == "fileops"
       
       // fileops calls desn't want root in path
-      var rootpath = fileop ? null : root
+      var rootpath = fileop ? "" : root
       
       // fileops calls desn't want scope in path
-      var scopepath = fileop ? null : scope
+      var scopepath = fileop ? "" : scope
 
       // we wont always have this
-      var filepath = obj.path ? qs.escape(obj.path) : null
+      var filepath = obj.path ? qs.escape(obj.path) : ""
       
       // build full path
       var fullpath = path.join(obj.hostname)


### PR DESCRIPTION
sets `config.scope` to `""` unless already set. also, `null` was replaced to `""`.

tested in node v0.10.2
