### PR TITLE
add support for chunked uploads

### DIFF
--- a/lib/dbox.js
+++ b/lib/dbox.js
@@ -195,6 +195,60 @@ exports.app = function(config){
           })
         },
 
+        chunk: function(body, args, cb){
+          if(!cb){
+            cb   = args
+            args = {}
+          }
+
+          var signature = helpers.sign(options, args)
+
+          var url = helpers.url({
+            hostname: "api-content.dropbox.com",
+            action: "chunked_upload",
+            // path: path,
+            root: "",
+            query: signature
+          });
+          
+          args["method"] = "PUT";
+          args["headers"] = { "content-length": body.length };
+          args["url"] = url;
+          
+          // do not send empty body
+          if(body.length > 0) args["body"] = body
+          
+          return request(args, function(e, r, b){
+            cb(e ? null : r.statusCode, e ? null : helpers.parseJSON(b))
+          })
+        },
+
+        commit_chunks: function(path, args, cb){
+          if(!cb){
+            cb   = args
+            args = null
+          }
+          
+          var signature = helpers.sign(options, args)
+
+          var url = helpers.url({
+            hostname: "api-content.dropbox.com",
+            action: "commit_chunked_upload",
+            path: path,
+            query: signature
+          })
+          
+          var args = {
+            "method": "POST",
+            "url": url
+          }
+          
+          return request(args, function(e, r, b){
+            cb(e ? null : r.statusCode, e ? null : helpers.parseJSON(b))
+          })
+        },
+
+
         metadata: function(path, args, cb){
           if(!cb){
             cb   = args

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -112,6 +112,9 @@ module.exports = function(config){
       
       // fileops calls desn't want root in path
       var rootpath = fileop ? "" : root
+
+      // override rootpath if obj.root is specified
+      if(typeof obj.root !== "undefined" && obj.root !== null) rootpath = obj.root;
       
       // fileops calls desn't want scope in path
       var scopepath = fileop ? "" : scope

--- a/test/all.js
+++ b/test/all.js
@@ -48,7 +48,7 @@ describe("all", function(){
       done()
     })
   })
-  
+
   it("should get metadatq of file", function(done) {
     client.metadata("myfirstfile.txt", function(status, reply){
       status.should.eql(200)


### PR DESCRIPTION
dbox has near complete coverage sans [/chunked_upload](https://www.dropbox.com/developers/core/docs#chunked-upload) and [/commit_chunked_upload](https://www.dropbox.com/developers/core/docs#commit-chunked-upload). This commit fixes that.

I couldn't get test cases to work - anything I wrote that called `chunk` would return 404, though all the other tests would pass and `chunk` works fine in my production code.
