### PR TITLE
Fix scopePath on Windows

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,7 +19,7 @@ module.exports = function(config){
     },
     
     parseJSON: function(str) {
-      var scopePath = path.join("/", scope)
+      var scopePath = path.join("/", scope).replace(/\\/gm, '/')
       var rx = RegExp("^" + scopePath, "i")
       
       try {


### PR DESCRIPTION
On windows the provided path slashes are "\" instead of "/"
