### PR TITLE
Fix url path on Windows

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -128,7 +128,7 @@ module.exports = function(config){
           fullpath = path.join(fullpath, filepath)
       
       // add protocol
-      var fullurl = "https://" + fullpath
+      var fullurl = "https://" + fullpath.replace(/\\/gm, '/')
       
       // add querystring if we have one
       if(obj.hasOwnProperty("query")) fullurl += ("?" + qs.stringify(obj.query))


### PR DESCRIPTION
On windows the provided slashes are "\" instead of "/"
