### PR TITLE
Add the ability to upload a file by passing a readable stream

### DIFF
--- a/lib/dbox.js
+++ b/lib/dbox.js
@@ -1,6 +1,7 @@
-var request = require("request")
-var qs      = require("querystring")
-var path    = require("path")
+var request     = require("request")
+var qs          = require("querystring")
+var path        = require("path")
+var isStream    = require("isstream")
 
 exports.app = function(config){
   var root   = config.root  || "sandbox"
@@ -185,15 +186,24 @@ exports.app = function(config){
             path: path,
             query: signature
           })
-          
+
           var args = {
             "method": "PUT",
-            "headers": { "content-length": body.length },
-            "url": url
+            "url": url,
+            body: body
           }
-          
-          // do not send empty body
-          if(body.length > 0) args["body"] = body
+
+          // Is buffer or string not a stream
+          if (!isStream(body)) {
+
+            args.headers = { "content-length": body.length };
+
+            // Do not send empty body
+            if(body.length === 0) {
+              delete args.body;
+            }
+            
+          }
           
           return request(args, function(e, r, b){
             cb(e ? null : r.statusCode, e ? null : helpers.parseJSON(b))

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     { "name": "Jeremiah Condon", "email": "jeremy@grit-design.com" },
     { "name": "John Titus", "email": "john.titus@gmail.com" },
     { "name": "Ben Buckman", "email": "ben.buckman@docusign.com" },
-    { "name": "Zach Ahn", "email": "zach.ahn@gmail.com" }
+    { "name": "Zach Ahn", "email": "zach.ahn@gmail.com" },
+    { "name": "Mohammad Fares", "email": "faressoft.com@gmail.com" },
   ],
   "keywords": ["dropbox", "sdk", "s3"],
   "main": "./lib/dbox.js",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "isstream": "^0.1.2",
-    "request": "2.9.153"
+    "request": "^2.72.0"
   },
   "devDependencies": {
     "mocha": "1.21.4",

--- a/package.json
+++ b/package.json
@@ -4,50 +4,120 @@
   "version": "0.6.4",
   "author": "Brock Whitten <brock@sintaxi.com>",
   "contributors": [
-    { "name": "Brock Whitten", "email": "brock@sintaxi.com" },
-    { "name": "Anton Podviaznikov", "email": "podviaznikov@gmail.com" },
-    { "name": "Tom Gallacher", "email": "tomgallacher23@gmail.com" },
-    { "name": "Emmanuel Boudrant", "email": "emmanuel.boudrant@gmail.com" },
-    { "name": "Danny Amey", "email": "git@dannyamey.com" },
-    { "name": "Michiel DeJong", "email": "michiel@unhosted.org" },
-    { "name": "Julien Cayzac", "email": "julien.cayzac@gmail.com" },
-    { "name": "Aleksandar Kolundzija", "email": "a@ak.rs" },
-    { "name": "Carl Sverre", "email": "accounts@carlsverre.com" },
-    { "name": "Leonardo D. Schlossmacher", "email": "e@leods92.com" },
-    { "name": "Sam Nguyen", "email": "samxnguyen@gmail.com" },
-    { "name": "Marak Squires", "email": "marak.squires@gmail.com" },
-    { "name": "Paul Ledbetter", "email": "mledbetter.paul@gmail.com" },
-    { "name": "James Allen", "email": "jamesallen0108@gmail.com" },
-    { "name": "Jesper Lindstrøm Nielsen", "email": "me@jstroem.com" },
-    { "name": "Rob Ellis", "email": "rob@chloi.io" },
-    { "name": "Jeremiah Condon", "email": "jeremy@grit-design.com" },
-    { "name": "John Titus", "email": "john.titus@gmail.com" },
-    { "name": "Ben Buckman", "email": "ben.buckman@docusign.com" },
-    { "name": "Zach Ahn", "email": "zach.ahn@gmail.com" },
-    { "name": "Mohammad Fares", "email": "faressoft.com@gmail.com" },
+    {
+      "name": "Brock Whitten",
+      "email": "brock@sintaxi.com"
+    },
+    {
+      "name": "Anton Podviaznikov",
+      "email": "podviaznikov@gmail.com"
+    },
+    {
+      "name": "Tom Gallacher",
+      "email": "tomgallacher23@gmail.com"
+    },
+    {
+      "name": "Emmanuel Boudrant",
+      "email": "emmanuel.boudrant@gmail.com"
+    },
+    {
+      "name": "Danny Amey",
+      "email": "git@dannyamey.com"
+    },
+    {
+      "name": "Michiel DeJong",
+      "email": "michiel@unhosted.org"
+    },
+    {
+      "name": "Julien Cayzac",
+      "email": "julien.cayzac@gmail.com"
+    },
+    {
+      "name": "Aleksandar Kolundzija",
+      "email": "a@ak.rs"
+    },
+    {
+      "name": "Carl Sverre",
+      "email": "accounts@carlsverre.com"
+    },
+    {
+      "name": "Leonardo D. Schlossmacher",
+      "email": "e@leods92.com"
+    },
+    {
+      "name": "Sam Nguyen",
+      "email": "samxnguyen@gmail.com"
+    },
+    {
+      "name": "Marak Squires",
+      "email": "marak.squires@gmail.com"
+    },
+    {
+      "name": "Paul Ledbetter",
+      "email": "mledbetter.paul@gmail.com"
+    },
+    {
+      "name": "James Allen",
+      "email": "jamesallen0108@gmail.com"
+    },
+    {
+      "name": "Jesper Lindstrøm Nielsen",
+      "email": "me@jstroem.com"
+    },
+    {
+      "name": "Rob Ellis",
+      "email": "rob@chloi.io"
+    },
+    {
+      "name": "Jeremiah Condon",
+      "email": "jeremy@grit-design.com"
+    },
+    {
+      "name": "John Titus",
+      "email": "john.titus@gmail.com"
+    },
+    {
+      "name": "Ben Buckman",
+      "email": "ben.buckman@docusign.com"
+    },
+    {
+      "name": "Zach Ahn",
+      "email": "zach.ahn@gmail.com"
+    },
+    {
+      "name": "Mohammad Fares",
+      "email": "faressoft.com@gmail.com"
+    }
   ],
-  "keywords": ["dropbox", "sdk", "s3"],
+  "keywords": [
+    "dropbox",
+    "sdk",
+    "s3"
+  ],
   "main": "./lib/dbox.js",
   "scripts": {
-     "test": "./node_modules/.bin/mocha -t 120000 test/all.js -R spec"
+    "test": "./node_modules/.bin/mocha -t 120000 test/all.js -R spec"
   },
-  "repository": { 
+  "repository": {
     "type": "git",
     "url": "https://github.com/sintaxi/node-dbox.git"
   },
   "dependencies": {
+    "isstream": "^0.1.2",
     "request": "2.9.153"
   },
-  "devDependencies": { 
+  "devDependencies": {
     "mocha": "1.21.4",
     "should": "4.0.4",
     "prompt": "0.1.12"
   },
-  "engines": { "node": "*" },
-  "licenses" : [
-    { 
-      "type" : "MIT",
-      "url" : "https://raw.github.com/sintaxi/node-dbox/master/README.md"
+  "engines": {
+    "node": "*"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://raw.github.com/sintaxi/node-dbox/master/README.md"
     }
   ]
 }


### PR DESCRIPTION
It is not a good idea to upload files using buffers that must be loaded into the memory before they can be passed to the .put() method to upload them, especially with very large files which exceeds the memory size.

So, I have added the ability to the .put() method to receive either a buffer(or string) or a readable stream without breaking the .put() api, so my changes is compatible with any previous usage of the method.

```
client.put(remoteFilePath, fs.createReadStream(localFilePath), function(status, reply) {

  if (status !== 200) {
    return exit('Uplading is failed');
  }

  exit('Done');

});

```
